### PR TITLE
fix: noticket - Use web URL when Twitter app is not installed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,14 +25,26 @@ export default class Autolink extends Component {
           case 'instagram':
             return `instagram://tag?name=${tag}`;
           case 'twitter':
-            return `twitter://search?query=%23${tag}`;
+            const twitterURL = `twitter://search?query=%23${tag}`;
+            Linking.canOpenURL(url).then(supported => {
+                if (!supported) {
+                    return `https://www.twitter.com/search?q=${tag}`;
+                }
+                return url;
+            })
           default:
             return match.getMatchedText();
         }
       case 'phone':
         return `tel:${match.getNumber()}`;
       case 'twitter':
-        return `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
+        const url = `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
+        Linking.canOpenURL(url).then(supported => {
+            if (!supported) {
+                return `https://www.twitter.com/${encodeURIComponent(match.getTwitterHandle())}`;
+            }
+            return url;
+        })
       case 'url':
         return match.getAnchorHref();
       default:


### PR DESCRIPTION
**Summary:**

react-native-autolink fails when the user doesn't have Twitter installed, this is sad.

**How to test:**

To be tested alongside [this PR](https://bitbucket.org/conversocial/conv_crowds_react/pull-requests/265/).
1. Install Twitter, ensure that clicking a hashtag or an @ link sends you to the Twitter app.
2. Uninstall Twitter, ensure that clicking a hashtag or an @ link sends you to the correct page in your web browser.