### PR TITLE
Handle the case where the Twitter/Instagram apps are not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-dom": "^15.3.1",
     "react-native": ">=0.25.0",
     "react-native-mock": "^0.2.6",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "sinon-stub-promise": "^3.0.1"
   },
   "peerDependencies": {
     "react-native": ">=0.25.0"

--- a/src/index.js
+++ b/src/index.js
@@ -25,28 +25,38 @@ export default class Autolink extends Component {
           case 'instagram':
             return `instagram://tag?name=${tag}`;
           case 'twitter':
-            const twitterURL = `twitter://search?query=%23${tag}`;
-            Linking.canOpenURL(url).then(supported => {
-                if (!supported) {
-                    return `https://www.twitter.com/search?q=${tag}`;
-                }
-                return url;
-            })
+            return `twitter://search?query=%23${tag}`;
           default:
             return match.getMatchedText();
         }
       case 'phone':
         return `tel:${match.getNumber()}`;
       case 'twitter':
-        const url = `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
-        Linking.canOpenURL(url).then(supported => {
-            if (!supported) {
-                return `https://www.twitter.com/${encodeURIComponent(match.getTwitterHandle())}`;
-            }
-            return url;
-        })
+        return `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
       case 'url':
         return match.getAnchorHref();
+      default:
+        return match.getMatchedText();
+    }
+  }
+
+  getFallbackURL(match) {
+    let type = match.getType();
+
+    switch(type) {
+      case 'hashtag':
+        let tag = encodeURIComponent(match.getHashtag());
+
+        switch(this.props.hashtag) {
+          case 'instagram':
+            return `https://www.instagram.com/explore/tags/${tag}`;
+          case 'twitter':
+            return `https://www.twitter.com/search?q=%23${tag}`;
+          default:
+            return match.getMatchedText();
+        }
+      case 'twitter':
+        return `https://www.twitter.com/${encodeURIComponent(match.getTwitterHandle())}`;
       default:
         return match.getMatchedText();
     }
@@ -56,7 +66,13 @@ export default class Autolink extends Component {
     if (this.props.onPress) {
       this.props.onPress(url, match);
     } else {
-      Linking.openURL(url);
+      Linking.canOpenURL(url).then(supported => {
+        if (!supported) {
+          Linking.openURL(this.getFallbackURL(match));
+        } else {
+          Linking.openURL(url);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
**Summary:**

Handling the case where Twitter/Instagram apps are not installed. (This is a requirement on top of the previous PR to get hashtags to work, turns out that bind()/switch/promises are not friends).

**How to test:**

1. Test alongside this: https://bitbucket.org/conversocial/conv_crowds_react/pull-requests/265/feat-crow-588-add-react-native-autolink-to/diff
2. Install Twitter, make sure that when you click on @ handles and hashtags you are sent to the Twitter app.
3. Uninstall Twitter, make sure that when you click on @ handles and hashtags you are sent to the appropriate place on the Twitter website.
4. Check that http links work.